### PR TITLE
Fixed TableInherit creating stackoverflow(s)

### DIFF
--- a/garrysmod/lua/includes/modules/scripted_ents.lua
+++ b/garrysmod/lua/includes/modules/scripted_ents.lua
@@ -25,7 +25,7 @@ local function TableInherit( t, base )
 		
 		if ( t[k] == nil ) then
 			t[k] = v
-		elseif ( istable( t[k] ) ) then
+		elseif ( istable( t[k] ) and ( k == "BaseClass" ) ) then
 			TableInherit( t[k], v )
 		end
 		


### PR DESCRIPTION
The TableInherit creates a stack-overflow when trying to copy table values other than those on the BaseClass key.
Now the function is limited to only inherit tables on the BaseClass key.